### PR TITLE
Fix toggleFilter function and change key binding from Ctrl+h to Alt+h

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ KEY script-binding cycle-histogram-pixel-format
 KEY script-binding cycle-histogram-levels-mode
 ```
 
-If you are using hardware decoding, the histogram will likely not work. However, you can use `Ctrl+h` (mpv default key binding) to toggle hardware decoding on/off on the fly.
+The histogram video filter will likely not work, if hardware decoding is used. Therefore, if hardware decoding is detected, it is disabled when the histogram is toggled on and the setting is restored when toggled off.
 
 ![Shamelessly stolen example from ffmpeg's wiki](https://trac.ffmpeg.org/raw-attachment/wiki/Histogram/histogram_overlay.jpg)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ There is a substantial amount of config available, but this script does *not* su
 There are three default keybinds:
  - `h`: Toggle the histogram on/off
  - `H` (`Shift+h`): Cycle between the pixel formats available
- - `Ctrl+h`: Toggle between linear and logarithmic levels
+ - `Alt+h`: Toggle between linear and logarithmic levels
 
 These keybinds can be changed by placing the following lines
 in your `input.conf`:
@@ -61,5 +61,7 @@ KEY script-binding toggle-histogram
 KEY script-binding cycle-histogram-pixel-format
 KEY script-binding cycle-histogram-levels-mode
 ```
+
+If you are using hardware decoding, the histogram will likely not work. However, you can use `Ctrl+h` (mpv default key binding) to toggle hardware decoding on/off on the fly.
 
 ![Shamelessly stolen example from ffmpeg's wiki](https://trac.ffmpeg.org/raw-attachment/wiki/Histogram/histogram_overlay.jpg)

--- a/histogram.lua
+++ b/histogram.lua
@@ -11,7 +11,7 @@
   * There are three default keybinds:
   *     h - Toggle the histogram on/off
   *     H - Cycle between the pixel formats available
-  *     Ctrl+h - Toggle between linear and logarithmic levels
+  *     Alt+h - Toggle between linear and logarithmic levels
   * These keybinds can be changed by placing the following lines
   * in your input.conf:
   *     KEY script-binding toggle-histogram
@@ -158,4 +158,4 @@ init()
 
 mp.add_key_binding("h", "toggle-histogram", toggleFilter)
 mp.add_key_binding("H", "cycle-histogram-pixel-format", cycleFmt)
-mp.add_key_binding("ctrl+h", "cycle-histogram-levels-mode", cycleLevels)
+mp.add_key_binding("Alt+h", "cycle-histogram-levels-mode", cycleLevels)

--- a/histogram.lua
+++ b/histogram.lua
@@ -1,7 +1,7 @@
 --[[
-  * histogram.lua v.2022-01-17
+  * histogram.lua v.2022-02-27
   *
-  * AUTHOR: detuur
+  * AUTHORS: detuur, microraptor
   * License: MIT
   * link: https://github.com/detuur/mpv-scripts
   * 


### PR DESCRIPTION
Thank you for the very useful script! Since I noticed very weird behavior on one of my computers I took a look at the code and fixed the toggleFilter function. This resolves the weird behavior described in issue #5, and makes the script function as it should ~on one of the computers~.

The function had two bugs:
1. If no video filter existed before, the toggle function would not create the histogram video filter as it should. Because skiptosilence.lua creates a video filter, this has probably gone unnoticed.
2. There is a return statement inside the for loop. So the loop would only run once and detect the histogram only, if it is the last video filter. This probably has gone unnoticed, because the histogram is mostly the last filter created.

Besides these fixes I also added comments and log messages.

The similar rebuildGraph functioned also correctly before, but I removed the unnecessary if statement, because in Lua a `for i = 0, 1, -1 do` loop doesn't even run the loop once.