### PR TITLE
skiptosilence: disable video/subtitle while skipping

### DIFF
--- a/skiptosilence.lua
+++ b/skiptosilence.lua
@@ -1,5 +1,5 @@
 --[[
-  * skiptosilence.lua v.2023-08-23
+  * skiptosilence.lua v.2023-08-27
   *
   * AUTHORS: detuur, microraptor, Eisa01
   * License: MIT

--- a/skiptosilence.lua
+++ b/skiptosilence.lua
@@ -159,7 +159,7 @@ function foundSilence(name, value)
 	end
 	
 	timecode = tonumber(string.match(value, "%d+%.?%d+"))
-	if timecode == nil or timecode < initial_skip_time + o.ignore_silence_duration then --1.03# this is to ignore silence
+	if timecode == nil or timecode < initial_skip_time + o.ignore_silence_duration then
 		return
 	end
 	

--- a/skiptosilence.lua
+++ b/skiptosilence.lua
@@ -1,5 +1,5 @@
 --[[
-  * skiptosilence.lua v.2023-08-18
+  * skiptosilence.lua v.2023-08-23
   *
   * AUTHORS: detuur, microraptor, Eisa01
   * License: MIT
@@ -69,6 +69,7 @@ pause_state = false
 mute_state = false
 sid_state = nil
 vid_state = nil
+window_state = nil
 skip_flag = false
 initial_skip_time = 0
 
@@ -77,6 +78,7 @@ function restoreProp(timepos,pause)
 	if not pause then pause = pause_state end
 	
 	mp.set_property("vid", vid_state)
+	mp.set_property("force-window", window_state)
 	mp.set_property("sid", sid_state)
 	mp.set_property_bool("mute", mute_state)
 	mp.set_property("speed", speed_state)
@@ -118,8 +120,8 @@ function doSkip()
 	initial_skip_time = (mp.get_property_native("time-pos") or 0)
 	if math.floor(initial_skip_time) == math.floor(mp.get_property_native('duration') or 0) then return end	
 
-	local width = mp.get_property_native("width");
-	local height = mp.get_property_native("height")
+	local width = mp.get_property_native("osd-width")
+	local height = mp.get_property_native("osd-height")
 	mp.set_property_native("geometry", ("%dx%d"):format(width, height))
 	
 	mp.command(
@@ -129,6 +131,8 @@ function doSkip()
 
 	mp.observe_property("af-metadata/skiptosilence", "string", foundSilence)
 
+	window_state = mp.get_property("force-window")
+	mp.set_property("force-window", "yes")
 	vid_state = mp.get_property("vid")
 	mp.set_property("vid", "no")
 	sid_state = mp.get_property("sid")

--- a/skiptosilence.lua
+++ b/skiptosilence.lua
@@ -67,7 +67,8 @@ local msg = require 'mp.msg'
 speed_state = 1
 pause_state = false
 mute_state = false
-sid_state = nil
+sub_state = nil
+secondary_sub_state = nil
 vid_state = nil
 window_state = nil
 skip_flag = false
@@ -79,13 +80,14 @@ function restoreProp(timepos,pause)
 	
 	mp.set_property("vid", vid_state)
 	mp.set_property("force-window", window_state)
-	mp.set_property("sid", sid_state)
 	mp.set_property_bool("mute", mute_state)
 	mp.set_property("speed", speed_state)
 	mp.unobserve_property(foundSilence)
 	mp.command("no-osd af remove @skiptosilence")
+	mp.set_property_bool("pause", pause)	
 	mp.set_property_number("time-pos", timepos)
-	mp.set_property_bool("pause", pause)
+	mp.set_property("sub-visibility", sub_state)
+	mp.set_property("secondary-sub-visibility", secondary_sub_state)	
 	timer:kill()
 	skip_flag = false
 end
@@ -131,12 +133,14 @@ function doSkip()
 
 	mp.observe_property("af-metadata/skiptosilence", "string", foundSilence)
 
+	sub_state = mp.get_property("sub-visibility")
+	mp.set_property("sub-visibility", "no")
+	secondary_sub_state = mp.get_property("secondary-sub-visibility")
+	mp.set_property("secondary-sub-visibility", "no")
 	window_state = mp.get_property("force-window")
 	mp.set_property("force-window", "yes")
 	vid_state = mp.get_property("vid")
 	mp.set_property("vid", "no")
-	sid_state = mp.get_property("sid")
-	mp.set_property("sid", "no")
 	mute_state = mp.get_property_native("mute")
     if o.force_mute_on_skip then
         mp.set_property_bool("mute", true)

--- a/skiptosilence.lua
+++ b/skiptosilence.lua
@@ -32,7 +32,7 @@ silence_duration=0.7
 
 #--(0/#number). The first detcted silence_duration will be ignored for the defined seconds in this option, and it will continue skipping until the next silence_duration.
 # (0 for disabled, or specify seconds).
-ignore_silence_duration=10
+ignore_silence_duration=1
 
 #--(0/#number). Minimum amount of seconds accepted to skip until the configured silence_duration.
 # (0 for disabled, or specify seconds)

--- a/skiptosilence.lua
+++ b/skiptosilence.lua
@@ -86,9 +86,7 @@ function foundSilence(name, value)
 		return -- For some reason these are sometimes emitted. Ignore.
 	end
 
-	timecode = tonumber(string.match(value, "%d+%.?%d+"))
-	time_pos = mp.get_property_native("time-pos")
-	if timecode == nil or timecode < time_pos + 1 then
+	if timecode == nil or timecode < initial_skip_time + 1 then
 		return -- Ignore anything less than a second ahead.
 	end
 	


### PR DESCRIPTION
Disabling the video and subtitle while skipping instead of applying a blackout filter, fixes #3.

When there are too many packets in the demuxer packet, caused by exceeding the expected inside a packet then skipping will not stop and result in the action to never end. This is resulted from subtitles and video output from my testing.

Also fixed the script-opts template in the same PR.